### PR TITLE
Update numbers to represent actual damage numers rather than halved numbers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,14 +14,14 @@ buildscript {
 }
 apply plugin: 'net.minecraftforge.gradle.forge'
 
-version = "1.12-1.14"
+version = "1.12-1.14.1"
 group= "boni" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "MmmMmmMmmMmm"
 
 minecraft {
-    version = "1.12.2-14.23.0.2512"
+    version = "1.12.2-14.23.5.2847"
     runDir = "run"
-    mappings = "snapshot_20171010"
+    mappings = "stable_39"
 }
 
 dependencies {

--- a/src/main/java/boni/dummy/ItemDummy.java
+++ b/src/main/java/boni/dummy/ItemDummy.java
@@ -13,7 +13,7 @@ import net.minecraft.world.World;
 public class ItemDummy extends Item {
 
   public ItemDummy() {
-    this.setUnlocalizedName("dummy");
+    this.setTranslationKey("dummy");
     this.setRegistryName("dummy");
     this.setCreativeTab(CreativeTabs.COMBAT);
   }

--- a/src/main/java/boni/dummy/client/RenderFloatingNumber.java
+++ b/src/main/java/boni/dummy/client/RenderFloatingNumber.java
@@ -56,7 +56,7 @@ public class RenderFloatingNumber extends Render<EntityFloatingNumber> {
     GL11.glRotatef(-this.renderManager.playerViewX, 1.0F, 0.0F, 0.0F);
 
     // draw it
-    String s = df.format(entity.damage / 2f);
+    String s = df.format(entity.damage);
     if(dps) {
       s = "DPS: " + s;
     }

--- a/src/main/java/boni/dummy/network/DamageMessage.java
+++ b/src/main/java/boni/dummy/network/DamageMessage.java
@@ -7,6 +7,8 @@ import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
 
+import java.text.DecimalFormat;
+
 import boni.dummy.EntityDummy;
 import boni.dummy.EntityFloatingNumber;
 import io.netty.buffer.ByteBuf;
@@ -46,6 +48,8 @@ public class DamageMessage implements IMessage {
 
   public static class MessageHandlerClient implements IMessageHandler<DamageMessage, IMessage> {
 
+    private static DecimalFormat df = new DecimalFormat("#.##");
+
     @Override
     public DamageMessage onMessage(final DamageMessage message, MessageContext ctx) {
       FMLCommonHandler.instance().getWorldThread(ctx.netHandler).addScheduledTask(new Runnable() {
@@ -55,7 +59,7 @@ public class DamageMessage implements IMessage {
           if(entity != null && entity instanceof EntityDummy) {
             EntityDummy dummy = (EntityDummy) entity;
             dummy.shake = message.shakeAmount;
-            dummy.setCustomNameTag(String.valueOf(message.damage));
+            dummy.setCustomNameTag(String.valueOf(df.format(message.damage)));
           }
           if(message.nrID > 0) {
             entity = Minecraft.getMinecraft().world.getEntityByID(message.nrID);

--- a/src/main/java/boni/dummy/network/DamageMessage.java
+++ b/src/main/java/boni/dummy/network/DamageMessage.java
@@ -55,7 +55,7 @@ public class DamageMessage implements IMessage {
           if(entity != null && entity instanceof EntityDummy) {
             EntityDummy dummy = (EntityDummy) entity;
             dummy.shake = message.shakeAmount;
-            dummy.setCustomNameTag(String.valueOf(message.damage / 2f));
+            dummy.setCustomNameTag(String.valueOf(message.damage));
           }
           if(message.nrID > 0) {
             entity = Minecraft.getMinecraft().world.getEntityByID(message.nrID);

--- a/src/main/resources/assets/testdummy/lang/en_US.lang
+++ b/src/main/resources/assets/testdummy/lang/en_US.lang
@@ -1,2 +1,3 @@
 item.dummy.name=Test Dummy
 tile.dummy.name=Test Dummy
+entity.Dummy.name=Test Dummy

--- a/src/main/resources/assets/testdummy/lang/zh_CN.lang
+++ b/src/main/resources/assets/testdummy/lang/zh_CN.lang
@@ -1,2 +1,3 @@
 item.dummy.name=试验假人
 tile.dummy.name=试验假人
+entity.Dummy.name=试验假人


### PR DESCRIPTION
Before this pull request, the mod would show you the damage value in terms of hearts. Meaning if you hit it for 2 damage with this mod, that means you hit for 2 hearts.

However, Minecraft keeps track of health and damage in terms of half hearts. In other words, 1 damage = 1 half heart. This means if your sword says it does 4 damage it means it does 2 hearts of damage.

This pull request changes the mod so that it displays damage the same way Minecraft keeps track of it. It also brings it in line with other mods like Toro's DamageIndicators.